### PR TITLE
feat: add default light theme variables

### DIFF
--- a/Lumos Docs.txt
+++ b/Lumos Docs.txt
@@ -341,6 +341,8 @@ Whenever `--swatch--brand-500` is applied as a background color, `--swatch--bran
 
 ## Connecting Theme to Component Props
 
+Every page must include a theme class on the `<body>` element so theme variables are defined immediately. `tokens.css` now applies the light theme by default through `:root`, but relying on it can cause a flash of unthemed content. Add `.u-theme-light` (or another `.u-theme-*` class) to ensure consistent rendering.
+
 ### 1. Create component variants for Inherit, Light, Dark, and any other themes
 
 The inherit variant should have no theme applied. It will inherit the theme of the page.

--- a/tokens.css
+++ b/tokens.css
@@ -156,8 +156,8 @@
 }
 
 /* ---------- Role Maps (Themes) ---------- */
-/* Light */
-.u-theme-light {
+/* Light (default) */
+:root, .u-theme-light {
   --theme--bg: var(--swatch--neutral-0);
   --theme--bg-muted: var(--swatch--neutral-50);
   --theme--text: var(--swatch--neutral-900);


### PR DESCRIPTION
## Summary
- set light theme variables on `:root` so pages have a default theme
- document requirement to include a theme class on `<body>`

## Testing
- `node - <<'NODE'
const fs=require('fs');
const css=fs.readFileSync('tokens.css','utf8');
const lines=css.split(/\n/);
const vars={};
let capture=false; let brace=0;
for(const line of lines){
  const trimmed=line.trim();
  if(trimmed.startsWith(':root') || trimmed.startsWith(':root,')) {
    capture=true;
  }
  if(capture){
    const m=trimmed.match(/(--[^:]+):\s*([^;]+);/);
    if(m){ vars[m[1]]=m[2].trim(); }
    if(trimmed.includes('{')) brace++;
    if(trimmed.includes('}')){ brace--; if(brace<=0){capture=false;} }
  }
}
function resolve(val, seen=new Set()){
  return val.replace(/var\((--[^)]+)\)/g, (full, name)=>{
    if(seen.has(name)) return '/*circular*/';
    seen.add(name);
    return resolve(vars[name] || '', seen);
  });
}
['--button--primary-bg','--button--secondary-bg','--input--bg','--input--border-focus'].forEach(k=>{
  console.log(k,'=>',resolve(vars[k]));
});
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68c720ba1c388326bd30a05e95eb7ec9